### PR TITLE
Fix builds for macports / homebrew on new image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
     - INSTALL_TYPE='macpython' VERSION=2.7.12
     - INSTALL_TYPE='macpython' VERSION=2.7
     - INSTALL_TYPE='macpython' VERSION=2.7.12 VENV=venv
+    # Python.org 3.3 installer won't install on default 10.11 travis image
     - INSTALL_TYPE='macpython' VERSION=3.4.4
     - INSTALL_TYPE='macpython' VERSION=3.4.4 VENV=venv
     - INSTALL_TYPE='macpython' VERSION=3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ env:
     - INSTALL_TYPE='macpython' VERSION=2.7.12
     - INSTALL_TYPE='macpython' VERSION=2.7
     - INSTALL_TYPE='macpython' VERSION=2.7.12 VENV=venv
-    - INSTALL_TYPE='macpython' VERSION=3.4.5
-    - INSTALL_TYPE='macpython' VERSION=3.4.5 VENV=venv
+    - INSTALL_TYPE='macpython' VERSION=3.4.4
+    - INSTALL_TYPE='macpython' VERSION=3.4.4 VENV=venv
     - INSTALL_TYPE='macpython' VERSION=3.5
     - INSTALL_TYPE='macpython' VERSION=3.5.2 VENV=venv
     - INSTALL_TYPE='macpython' VERSION=3.6.0a3 VENV=venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,13 @@ language:
 
 env:
   matrix:
-    - INSTALL_TYPE='macpython' VERSION=2.7.7
+    - INSTALL_TYPE='macpython' VERSION=2.7.12
     - INSTALL_TYPE='macpython' VERSION=2.7
-    - INSTALL_TYPE='macpython' VERSION=2.7.7 VENV=venv
-    - INSTALL_TYPE='macpython' VERSION=3.3.5
-    - INSTALL_TYPE='macpython' VERSION=3.3.5 VENV=venv
-    - INSTALL_TYPE='macpython' VERSION=3.4.1
-    - INSTALL_TYPE='macpython' VERSION=3.4.1 VENV=venv
+    - INSTALL_TYPE='macpython' VERSION=2.7.12 VENV=venv
+    - INSTALL_TYPE='macpython' VERSION=3.4.5
+    - INSTALL_TYPE='macpython' VERSION=3.4.5 VENV=venv
     - INSTALL_TYPE='macpython' VERSION=3.5
-    - INSTALL_TYPE='macpython' VERSION=3.5.1 VENV=venv
+    - INSTALL_TYPE='macpython' VERSION=3.5.2 VENV=venv
     - INSTALL_TYPE='macpython' VERSION=3.6.0a3 VENV=venv
     - INSTALL_TYPE='macports' VERSION=2.7
     - INSTALL_TYPE='macports' VERSION=2.7 VENV=venv

--- a/test_osx_versions.sh
+++ b/test_osx_versions.sh
@@ -1,0 +1,12 @@
+# Test OSX version munging
+if [ "$(osx_version2version_name 10.6)" != "10.6-SnowLeopard" ]; then RET=1; fi
+if [ "$(osx_version2version_name 10.7)" != "10.7-Lion" ]; then RET=1; fi
+if [ "$(osx_version2version_name 10.8)" != "10.8-MountainLion" ]; then RET=1; fi
+if [ "$(osx_version2version_name 10.9)" != "10.9-Mavericks" ]; then RET=1; fi
+if [ "$(osx_version2version_name 10.10)" != "10.10-Yosemite" ]; then RET=1; fi
+if [ "$(osx_version2version_name 10.11)" != "10.11-ElCapitan" ]; then RET=1; fi
+if [ "$(osx_version2version_name 10.12)" != "10.12-Sierra" ]; then RET=1; fi
+if [ "$(osx_version2version_name 10.9.5)" != "10.9-Mavericks" ]; then RET=1; fi
+if [ "$(osx_version2version_name 10.10.2)" != "10.10-Yosemite" ]; then RET=1; fi
+if [ "$(osx_version2version_name 10.11.1)" != "10.11-ElCapitan" ]; then RET=1; fi
+if [ "$(osx_version2version_name 10.12.7)" != "10.12-Sierra" ]; then RET=1; fi

--- a/test_tools.sh
+++ b/test_tools.sh
@@ -8,5 +8,6 @@ source test_pyver_ge.sh
 source test_fill_pyver.sh
 source test_git_utils.sh
 source test_library_installers.sh
+source test_osx_versions.sh
 # Set the final return code
 (exit $RET)

--- a/travis_tools.sh
+++ b/travis_tools.sh
@@ -4,6 +4,18 @@
 # Get our own location on this filesystem
 TERRYFY_DIR=$(dirname "${BASH_SOURCE[0]}")
 
+# Work round bug in travis xcode image described at
+# https://github.com/direnv/direnv/issues/210
+function is_function {
+    # Echo "true" if input argument string is a function
+    # Allow errors during "set -e" blocks.
+    (set +e; echo $($(declare -Ff "$1") > /dev/null && echo true))
+}
+
+if [ -z "$(is_function "shell_session_update")" ]; then
+    shell_session_update() { :; }
+fi
+
 # Get multibuild utilities
 (cd $TERRYFY_DIR && git submodule update --init)
 source $TERRYFY_DIR/multibuild/osx_utils.sh
@@ -16,11 +28,6 @@ MACPORTS_PY_PREFIX=$MACPORTS_PREFIX$MACPYTHON_PY_PREFIX
 # https://lists.macosforge.org/pipermail/macports-users/2014-June/035672.html
 PORT_INSTALL="sudo port -q install"
 NIPY_WHEELHOUSE=https://nipy.bic.berkeley.edu/scipy_installers
-
-# Work round bug in travis xcode image described at
-# https://github.com/direnv/direnv/issues/210
-shell_session_update() { :; }
-
 
 function get_osx_version {
     # Echo OSX version

--- a/travis_tools.sh
+++ b/travis_tools.sh
@@ -8,7 +8,8 @@ TERRYFY_DIR=$(dirname "${BASH_SOURCE[0]}")
 (cd $TERRYFY_DIR && git submodule update --init)
 source $TERRYFY_DIR/multibuild/osx_utils.sh
 
-# For OSX image 6.4
+# For OSX image 7.3 - currently the default
+# https://docs.travis-ci.com/user/osx-ci-environment
 MACPORTS_VERSION=2.3.5
 MACPORTS_URL=https://github.com/macports/macports-base/releases/download/v$MACPORTS_VERSION
 MACPORTS_PKG=MacPorts-$MACPORTS_VERSION-10.11-ElCapitan.pkg

--- a/travis_tools.sh
+++ b/travis_tools.sh
@@ -11,7 +11,7 @@ source $TERRYFY_DIR/multibuild/osx_utils.sh
 # For OSX image 6.4
 MACPORTS_VERSION=2.3.5
 MACPORTS_URL=https://github.com/macports/macports-base/releases/download/v$MACPORTS_VERSION
-MACPORTS_PKG=MacPorts-$MACPORTS_VERSION-10.10-Yosemite.pkg
+MACPORTS_PKG=MacPorts-$MACPORTS_VERSION-10.11-ElCapitan.pkg
 MACPORTS_PREFIX=/opt/local
 MACPORTS_PY_PREFIX=$MACPORTS_PREFIX$MACPYTHON_PY_PREFIX
 # -q to avoid this:

--- a/travis_tools.sh
+++ b/travis_tools.sh
@@ -17,6 +17,10 @@ MACPORTS_PY_PREFIX=$MACPORTS_PREFIX$MACPYTHON_PY_PREFIX
 PORT_INSTALL="sudo port -q install"
 NIPY_WHEELHOUSE=https://nipy.bic.berkeley.edu/scipy_installers
 
+# Work round bug in travis xcode image described at
+# https://github.com/direnv/direnv/issues/210
+shell_session_update() { :; }
+
 
 function require_success {
     local status=$?
@@ -125,9 +129,8 @@ function brew_install_python {
     if [[ "$py_digit" == "3" ]] ; then
         brew install python3
     else
+        brew uninstall --force --ignore-dependencies python
         brew install python
-        # Now easy_install and pip are in /usr/local we need to force link
-        brew link --overwrite python
     fi
     require_success "Failed to install python"
     PYTHON_EXE=/usr/local/bin/python$py_digit

--- a/travis_tools.sh
+++ b/travis_tools.sh
@@ -8,8 +8,10 @@ TERRYFY_DIR=$(dirname "${BASH_SOURCE[0]}")
 (cd $TERRYFY_DIR && git submodule update --init)
 source $TERRYFY_DIR/multibuild/osx_utils.sh
 
-MACPORTS_URL=https://distfiles.macports.org/MacPorts
-MACPORTS_PKG=MacPorts-2.3.3-10.9-Mavericks.pkg
+# For OSX image 6.4
+MACPORTS_VERSION=2.3.5
+MACPORTS_URL=https://github.com/macports/macports-base/releases/download/v$MACPORTS_VERSION
+MACPORTS_PKG=MacPorts-$MACPORTS_VERSION-10.10-Yosemite.pkg
 MACPORTS_PREFIX=/opt/local
 MACPORTS_PY_PREFIX=$MACPORTS_PREFIX$MACPYTHON_PY_PREFIX
 # -q to avoid this:

--- a/travis_tools.sh
+++ b/travis_tools.sh
@@ -74,7 +74,7 @@ function install_macports {
     # Initialize macports, put macports on PATH
     local macports_path=$DOWNLOADS_SDIR/$MACPORTS_PKG
     mkdir -p $DOWNLOADS_SDIR
-    curl $MACPORTS_URL/$MACPORTS_PKG > $macports_path
+    curl -L $MACPORTS_URL/$MACPORTS_PKG > $macports_path
     require_success "failed to download macports"
     sudo installer -pkg $macports_path -target /
     require_success "failed to install macports"


### PR DESCRIPTION
Travis-ci default xcode image is now 7.3, OSX 10.11.  This needs a new macports
installer.

Disable Python 3.3 for Python.org - it appears it can't be installed on 7.3.

Add homebrew fix from gh-8.